### PR TITLE
Use named import to access render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import 'babel-polyfill';
-import render from 'react-dom';
+import {render} from 'react-dom';
 import React,{PropTypes} from 'react';
 import route from './route';
 import {Router,browserHistory} from 'react-router'; //REMEMBER THAT browserHistory IS USED FOR MODERN BROWSERS THAT SUPPORT HTML5 PUSH STATE(),FOR MORE http://html5.gingerhost.com/


### PR DESCRIPTION
The import you had resolved to nothing because you have to specify that you want the render property which is part of react-dom (via a named import).